### PR TITLE
Add natural language email actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,24 @@ This command will bundle your agent and deploy it to the cloud, making it access
 
 Your project configuration is stored in `agentuity.yaml`. This file defines your agents, development settings, and deployment configuration.
 
+## ✉️ Email Actions
+
+The `actions` agent can create and store email automation rules from plain text instructions. Each rule is saved using the following structure:
+
+```ts
+interface EmailAction {
+  id: string;
+  description: string;
+  action: "notify" | "summarize";
+  criteria: string;
+  createdAt: string;
+}
+```
+
+Example requests include:
+- "send me a notification of an urgent email or from someone that I am actively engaged in a conversation with."
+- "summarize my inbox every morning but only include important emails in the summary."
+
 ## 🛠️ Advanced Usage
 
 ### Environment Variables

--- a/src/agents/actions/index.ts
+++ b/src/agents/actions/index.ts
@@ -1,6 +1,10 @@
 import type { AgentRequest, AgentResponse, AgentContext } from '@agentuity/sdk';
-import { generateText } from 'ai';
+import { generateObject } from 'ai';
+import { z } from 'zod';
 import { anthropic } from '@ai-sdk/anthropic';
+import { randomUUID } from 'crypto';
+import type { EmailAction } from './types.js';
+import { saveAction } from './store.js';
 
 export const welcome = () => {
   return {
@@ -19,15 +23,45 @@ export const welcome = () => {
   };
 };
 
+async function interpretAction(text: string): Promise<Omit<EmailAction, 'id' | 'createdAt'>> {
+  const systemPrompt = `You convert user requests about email actions into JSON.\nReturn only JSON with fields action (notify|summarize), criteria, and description.`;
+  const schema = z.object({
+    action: z.enum(['notify', 'summarize']),
+    criteria: z.string(),
+    description: z.string(),
+  });
+
+  try {
+    const result = await generateObject({
+      model: anthropic('claude-3-5-sonnet-latest'),
+      system: systemPrompt,
+      prompt: text,
+      schema,
+    });
+    return result.object;
+  } catch {
+    return {
+      action: 'notify',
+      criteria: text,
+      description: text,
+    };
+  }
+}
+
 export default async function Agent(
   req: AgentRequest,
   resp: AgentResponse,
-  ctx: AgentContext
+  ctx: AgentContext,
 ) {
-  const res = await generateText({
-    model: anthropic('claude-3-5-sonnet-latest'),
-    system: 'You are a friendly assistant!',
-    prompt: (await req.data.text()) ?? 'Why is the sky blue?',
-  });
-  return resp.text(res.text);
+  const input = (await req.data.text()) ?? '';
+  const parsed = await interpretAction(input);
+  const action: EmailAction = {
+    id: randomUUID(),
+    createdAt: new Date().toISOString(),
+    ...parsed,
+  };
+
+  await saveAction(ctx, action);
+  ctx.logger.info('Stored action %s', action.id);
+  return resp.json({ message: 'Action stored', action });
 }

--- a/src/agents/actions/index.ts
+++ b/src/agents/actions/index.ts
@@ -53,8 +53,12 @@ export default async function Agent(
   resp: AgentResponse,
   ctx: AgentContext,
 ) {
-  const input = (await req.data.text()) ?? '';
+  const input = (await req.data.text())?.trim();
+  if (!input) {
+    return resp.status(400).json({ error: 'No instruction provided' });
+  }
   const parsed = await interpretAction(input);
+
   const action: EmailAction = {
     id: randomUUID(),
     createdAt: new Date().toISOString(),

--- a/src/agents/actions/store.ts
+++ b/src/agents/actions/store.ts
@@ -1,0 +1,21 @@
+import type { AgentContext } from '@agentuity/sdk';
+import type { EmailAction } from './types';
+
+const STORE_NAME = 'email_actions';
+const STORE_KEY = 'list';
+
+export async function saveAction(
+  ctx: AgentContext,
+  action: EmailAction,
+): Promise<void> {
+  const current = ((await ctx.kv.get(STORE_NAME, STORE_KEY)) as EmailAction[]) ?? [];
+  current.push(action);
+  await ctx.kv.set(STORE_NAME, STORE_KEY, current);
+}
+
+export async function getActions(
+  ctx: AgentContext,
+): Promise<EmailAction[]> {
+  const current = ((await ctx.kv.get(STORE_NAME, STORE_KEY)) as EmailAction[]) ?? [];
+  return current;
+}

--- a/src/agents/actions/types.ts
+++ b/src/agents/actions/types.ts
@@ -1,0 +1,11 @@
+export interface EmailAction {
+  id: string;
+  /** Natural language description of the action */
+  description: string;
+  /** Type of action to perform */
+  action: 'notify' | 'summarize';
+  /** Criteria for when the action should run */
+  criteria: string;
+  /** ISO timestamp when the action was created */
+  createdAt: string;
+}


### PR DESCRIPTION
## Summary
- build infrastructure for saving email actions using KV storage
- parse natural language text into actions
- document the new `EmailAction` structure
- update action parser to use `generateObject`

## Testing
- `npm run lint` *(fails: biome not found)*
- `npm test` *(fails: no test specified)*

This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced the ability to create and store email automation rules from plain text instructions, supporting actions like notifications and summaries based on user-defined criteria.

- **Documentation**
  - Added a new "Email Actions" section to the README with usage examples and details about available automation actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->