### PR TITLE
Add natural language list command

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ Example requests include:
 - "send me a notification of an urgent email or from someone that I am actively engaged in a conversation with."
 - "summarize my inbox every morning but only include important emails in the summary."
 
+To see the actions you've already saved, ask the `actions` agent with a natural language prompt such as "show my saved actions". The agent will return the current action objects as JSON.
+
 ## 🛠️ Advanced Usage
 
 ### Environment Variables

--- a/src/agents/actions/index.ts
+++ b/src/agents/actions/index.ts
@@ -55,11 +55,17 @@ async function interpretInstruction(text: string): Promise<Instruction> {
     if (obj.command === 'list') {
       return { command: 'list' };
     }
+    
+    // Validate required fields for create command
+    if (!obj.action || !obj.criteria || !obj.description) {
+      throw new Error('Missing required fields for create command');
+    }
+    
     return {
       command: 'create',
-      action: obj.action!,
-      criteria: obj.criteria!,
-      description: obj.description!,
+      action: obj.action,
+      criteria: obj.criteria,
+      description: obj.description,
     };
   } catch {
     if (/\blist|show|display\b/i.test(text)) {


### PR DESCRIPTION
## Summary
- interpret input as either `create` or `list`
- allow listing saved actions via the main `actions` agent
- document prompting the agent to "show my saved actions"

## Testing
- `npm run lint` *(fails: biome not found)*
- `npm run format` *(fails: biome not found)*
- `npm test` *(fails: no test specified)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the ability for users to view their saved email action rules using a natural language prompt (e.g., "show my saved actions").
- **Documentation**
  - Updated the README with instructions on how to view saved email action rules by querying the actions agent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->