### PR TITLE
Add skeleton preferences agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,10 @@ Example requests include:
 
 To see the actions you've already saved, ask the `actions` agent with a natural language prompt such as "show my saved actions". The agent will return the current action objects as JSON.
 
+## 🗒️ Email Preferences
+
+The `preferences` agent will manage user-defined email settings. For now it returns a placeholder response so you can build additional features later.
+
 ## 🛠️ Advanced Usage
 
 ### Environment Variables

--- a/agentuity.yaml
+++ b/agentuity.yaml
@@ -68,3 +68,6 @@ agents:
     name: actions
     # The description of the Agent which is editable
     description: Agent to manage actions to take based on email events
+  - id: agent_a17ceeedf35f98ee6389065839883603
+    name: preferences
+    description: Agent to manage user email preferences

--- a/src/agents/preferences/index.ts
+++ b/src/agents/preferences/index.ts
@@ -1,0 +1,10 @@
+import type { AgentRequest, AgentResponse, AgentContext } from '@agentuity/sdk';
+
+export default async function Agent(
+  req: AgentRequest,
+  resp: AgentResponse,
+  ctx: AgentContext,
+) {
+  ctx.logger.info('Preferences agent invoked');
+  return resp.json({ message: 'Preferences agent not implemented yet' });
+}

--- a/src/agents/preferences/store.ts
+++ b/src/agents/preferences/store.ts
@@ -1,0 +1,21 @@
+import type { AgentContext } from '@agentuity/sdk';
+import type { EmailPreference } from './types.js';
+
+const STORE_NAME = 'email_preferences';
+const STORE_KEY = 'list';
+
+export async function savePreference(
+  ctx: AgentContext,
+  pref: EmailPreference,
+): Promise<void> {
+  const current = ((await ctx.kv.get(STORE_NAME, STORE_KEY)) as EmailPreference[]) ?? [];
+  current.push(pref);
+  await ctx.kv.set(STORE_NAME, STORE_KEY, current);
+}
+
+export async function getPreferences(
+  ctx: AgentContext,
+): Promise<EmailPreference[]> {
+  const current = ((await ctx.kv.get(STORE_NAME, STORE_KEY)) as EmailPreference[]) ?? [];
+  return current;
+}

--- a/src/agents/preferences/types.ts
+++ b/src/agents/preferences/types.ts
@@ -1,0 +1,7 @@
+export interface EmailPreference {
+  id: string;
+  /** Natural language description of the preference */
+  description: string;
+  /** ISO timestamp when the preference was created */
+  createdAt: string;
+}


### PR DESCRIPTION
## Summary
- register a new `preferences` agent in `agentuity.yaml`
- add skeleton agent implementation at `src/agents/preferences`
- document the new agent in README

## Testing
- `npm test` *(fails: no test specified)*
- `npx biome format --write .` *(fails: EHOSTUNREACH to registry.npmjs.org)*